### PR TITLE
Implemented modern gitignore system

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,6 +72,26 @@
         "type": "github"
       }
     },
+    "hercules-ci-gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1716357214,
@@ -170,6 +190,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hercules-ci-gitignore": "hercules-ci-gitignore",
         "nixpkgs": "nixpkgs",
         "polykey-cli": "polykey-cli"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,41 +5,25 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
 
-    # Custom packages
     polykey-cli.url = "github:MatrixAI/Polykey-CLI";
-    polykey-cli.inputs.nixpkgs.follows = "nixpkgs"; # Inheriting the nixpkgs input above; pinned
+    polykey-cli.inputs.nixpkgs.follows = "nixpkgs";
+
+    hercules-ci-gitignore.url = "github:hercules-ci/gitignore.nix";
+    hercules-ci-gitignore.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ nixpkgs, flake-utils, ... }:
+  outputs = inputs@{ ... }:
     let
       overlay = import ./overlays/overlay.nix {
-        inherit inputs; # Import the inputs into the overlay.nix
+        inherit inputs;
       };
 
       modules = import ./modules/module-list.nix {
-        inherit inputs; # Same here
+        inherit inputs;
       };
     in
     {
-      overlays.default = overlay; # Overlay exposed to external flakes
-
-      nixosModules.default = modules; # Modules exposed to external flakes
-    } //
-
-    # The rest of this code is for testing purposes
-    flake-utils.lib.eachSystem flake-utils.lib.allSystems (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ overlay ];
-        };
-      in
-      {
-        devShells.default = with pkgs; mkShell {
-          buildInputs = [
-            polykey-cli
-          ];
-        };
-      }
-    );
+      overlays.default = overlay;
+      nixosModules.default = modules;
+    };
 }

--- a/overlays/overlay.nix
+++ b/overlays/overlay.nix
@@ -1,8 +1,9 @@
 { inputs }:
 
 final: prev:
-
-{
+let
+  inherit (import inputs.hercules-ci-gitignore { inherit (final) lib; }) gitignoreFilterWith;
+in {
   nixos = configuration:
     let
       modules = import ../modules/module-list.nix { inherit inputs; };
@@ -14,4 +15,21 @@ final: prev:
       );
 
   polykey-cli = inputs.polykey-cli.packages.x86_64-linux.default;
+
+  # A utility function to ignore files from the nix store based on the rules
+  # specified in the .gitignore file along with any additional filters that we
+  # have specified. Functionally works similar to nix-gitignore's syntax of:
+  # filteredFiles = gitignore [ "ignoreThisFile", "ignoreThisToo" ] ./.;
+  # In this case, filteredFiles will not contain "ignoreThisFile", 
+  # "ignoreThisToo", along with all the rules specified in the .gitignore file.
+  gitignore = excludes: src:
+    let
+      gitignoreContents = builtins.readFile (src + "/.gitignore");
+      extraRules = builtins.concatStringsSep "\n" excludes;
+      srcIgnored = gitignoreFilterWith {
+        basePath = src;
+        extraRules = "${gitignoreContents}\n${extraRules}";
+      };
+    in
+      builtins.filterSource (path: type: srcIgnored path type) src;
 }


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
This PR adds `gitignore`, which works as the next-generation `nix-gitignore`, which is deprecated now. `gitignore` uses [`hercules-ci/gitignore.nix`](https://github.com/hercules-ci/gitignore.nix) and appends extra files to ignore as specified.

#### Why this is better
As mentioned before, this `gitignore` automatically ignores the `.git` directory, which was not the default behaviour in `nix-gitignore` (as mentioned in the parent issue). Moreover, `nix-gitignore` is deprecated as of January 21, 2022 ([source](https://github.com/siers/nix-gitignore)). We needed to switch over to using Hercules CI's gitignore, as it was meant to be a replacement for `nix-gitignore`. As such, my implementation relies on a function provided by Hercules CI's gitignore. The reason I had to write up a wrapper is because by default, Hercules CI's gitignore only ignores any and all files mentioned on the `.gitignore` file only. For a more fine-grained control over the excluded files, I had to append more patterns to exclude, which is what I have implemented.

#### Usage:
```nix
src = pkgs.gitignore ["LICENSE" "README.md" "modules"] ./.;
```

To run the test, change the contents of the list immediately after `pkgs.gitignore` in `packages.gitignore` and run:

```console
$ nix flake .\#gitignore
```

This will symlink a directory `result` in the project root, and running `ls` on it will reveal the filtered nix store.

As a comparison, the result of running `ls` on the project directory as-is is:
```console
$ ls -la
drwxr-xr-x     - aryanj 19 Jun 17:54  .git/
drwxr-xr-x     - aryanj 19 Jun 14:46  modules/
drwxr-xr-x     - aryanj 19 Jun 16:59  overlays/
.rw-r--r--     9 aryanj 19 Jun 14:46  .gitignore
.rw-r--r--   11k aryanj 19 Jun 14:46  LICENSE
.rw-r--r--  2.6k aryanj 19 Jun 14:46  README.md
.rw-r--r--  2.9k aryanj 19 Jun 14:46  flake.lock
.rw-r--r--  2.0k aryanj 19 Jun 17:51  flake.nix
```

This can be contrasted against the filtered store output, which looks like this (it is filtering `LICENSE`, `README.md`, `modules/`, `.git/`, and `.gitignore`):
```console
$ ls result -la
dr-xr-xr-x     - root  1 Jan  1970  overlays/
.r--r--r--  2.9k root  1 Jan  1970  flake.lock
.r--r--r--  1.9k root  1 Jan  1970  flake.nix
```

As you can see, `gitignore` automatically omits the `.git` directory and the `.gitignore` file from the store, plus any additional files/directories we added to the list. Note that `result` is a symlink to the actual location of the package in the nix store, which is why their creation date is unset and there are no write permissions.

### Issues Fixed
<!-- List all issues fixed by this PR. -->
* Fixes #3 (INF-24)

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Add `gitignore`
- [x] 2. Test `gitignore`
- [x] 3. profit

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
